### PR TITLE
travis: test php7.3 instead of nightly while travis messes around

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  - nightly
+  - 7.3
 
 env:
   - PHPUNIT=true


### PR DESCRIPTION
currently, 'nightly' refers to php/master because php/7.4 was branched off already.. we can defer testing on 7.4 til there's a proper tag for it (currently '74-snapshot' works, but not sure how future proof it is)